### PR TITLE
fix: add verfied code in `callbackOnVerification` callback

### DIFF
--- a/docs/content/docs/plugins/phone-number.mdx
+++ b/docs/content/docs/plugins/phone-number.mdx
@@ -16,13 +16,13 @@ The phone number plugin extends the authentication system by allowing users to s
         import { phoneNumber } from "better-auth/plugins"
 
         const auth = betterAuth({
-            plugins: [ 
+            plugins: [
                 phoneNumber({  // [!code highlight]
                     sendOTP: ({ phoneNumber, code }, ctx) => { // [!code highlight]
                         // Implement sending OTP code via SMS // [!code highlight]
                     } // [!code highlight]
                 }) // [!code highlight]
-            ] 
+            ]
         })
         ```
     </Step>
@@ -71,7 +71,7 @@ To send an OTP to a user's phone number for verification, you can use the `sendV
 ```ts
 type sendPhoneNumberOTP = {
     /**
-     * Phone number to send OTP. 
+     * Phone number to send OTP.
      */
     phoneNumber: string = "+1234567890"
 }
@@ -86,19 +86,19 @@ After the OTP is sent, users can verify their phone number by providing the code
 ```ts
 type verifyPhoneNumber = {
     /**
-     * Phone number to verify. 
+     * Phone number to verify.
      */
     phoneNumber: string = "+1234567890"
     /**
-     * OTP code. 
+     * OTP code.
      */
     code: string = "123456"
     /**
-     * Disable session creation after verification. 
+     * Disable session creation after verification.
      */
     disableSession?: boolean = false
     /**
-     * Check if there is a session and update the phone number. 
+     * Check if there is a session and update the phone number.
      */
     updatePhoneNumber?: boolean = true
 }
@@ -146,15 +146,15 @@ In addition to signing in a user using send-verify flow, you can also use phone 
 ```ts
 type signInPhoneNumber = {
     /**
-     * Phone number to sign in. 
+     * Phone number to sign in.
      */
     phoneNumber: string = "+1234567890"
     /**
-     * Password to use for sign in. 
+     * Password to use for sign in.
      */
     password: string
     /**
-     * Remember the session. 
+     * Remember the session.
      */
     rememberMe?: boolean = true
 }
@@ -171,7 +171,7 @@ await authClient.phoneNumber.sendOtp({
 })
 ```
 
-Then verify the new phone number with the OTP code. 
+Then verify the new phone number with the OTP code.
 
 ```ts title="auth-client.ts"
 const isVerified = await authClient.phoneNumber.verify({
@@ -204,7 +204,7 @@ To initiate a request password reset flow using `phoneNumber`, you can start by 
 ```ts
 type requestPasswordResetPhoneNumber = {
     /**
-     * The phone number which is associated with the user. 
+     * The phone number which is associated with the user.
      */
     phoneNumber: string = "+1234567890"
 }
@@ -217,15 +217,15 @@ Then, you can reset the password by calling `resetPassword` on the client with t
 ```ts
 type resetPasswordPhoneNumber = {
     /**
-     * The one time password to reset the password. 
+     * The one time password to reset the password.
      */
     otp: string = "123456"
     /**
-     * The phone number to the account which intends to reset the password for. 
+     * The phone number to the account which intends to reset the password for.
      */
     phoneNumber: string = "+1234567890"
     /**
-     * The new password. 
+     * The new password.
      */
     newPassword: string = "new-and-secure-password"
 }
@@ -257,7 +257,7 @@ export const auth = betterAuth({
             sendOTP: ({ phoneNumber, code }, ctx) => {
                 // Implement sending OTP code via SMS
             },
-            callbackOnVerification: async ({ phoneNumber, user }, ctx) => { // [!code highlight]
+            callbackOnVerification: async ({ phoneNumber, user, verifiedCode }, ctx) => { // [!code highlight]
                 // Implement callback after phone number verification // [!code highlight]
             } // [!code highlight]
         })
@@ -311,24 +311,24 @@ An object with the following properties:
 ### `requireVerification`
 
 When enabled, users cannot sign in with their phone number until it has been verified. If an unverified user attempts to sign in, the server will respond with a 401 error (PHONE_NUMBER_NOT_VERIFIED) and automatically trigger an OTP send to start the verification process.
-    
+
 ## Schema
 
-The plugin requires 2 fields to be added to the user table 
+The plugin requires 2 fields to be added to the user table
 
 ### User Table
 <DatabaseTable
     fields={[
-        { 
-            name: "phoneNumber", 
-            type: "string", 
+        {
+            name: "phoneNumber",
+            type: "string",
             description: "The phone number of the user",
             isUnique: true,
             isOptional: true
         },
-        { 
-            name: "phoneNumberVerified", 
-            type: "boolean", 
+        {
+            name: "phoneNumberVerified",
+            type: "boolean",
             description: "Whether the phone number is verified or not",
             defaultValue: false,
             isOptional: true

--- a/packages/better-auth/src/plugins/phone-number/routes.ts
+++ b/packages/better-auth/src/plugins/phone-number/routes.ts
@@ -616,6 +616,7 @@ export const verifyPhoneNumber = (opts: RequiredPhoneNumberOptions) =>
 				{
 					phoneNumber: ctx.body.phoneNumber,
 					user,
+					verifiedCode: opts.code,
 				},
 				ctx,
 			);

--- a/packages/better-auth/src/plugins/phone-number/types.ts
+++ b/packages/better-auth/src/plugins/phone-number/types.ts
@@ -84,6 +84,7 @@ export interface PhoneNumberOptions {
 				data: {
 					phoneNumber: string;
 					user: UserWithPhoneNumber;
+					verifiedCode: string;
 				},
 				ctx?: GenericEndpointContext,
 		  ) => Awaitable<void>)


### PR DESCRIPTION
Adds a new field in `callbackOnVerification` callback function: `verifiedCode` which can be used later.

The new API:

```ts
export const auth = betterAuth({
    plugins: [
        phoneNumber({
            sendOTP: ({ phoneNumber, code }, ctx) => {
                // Implement sending OTP code via SMS
            },
            callbackOnVerification: async ({ phoneNumber, user, verifiedCode }, ctx) => { // [!code highlight]
                // Implement callback after phone number verification // [!code highlight]
            } // [!code highlight]
        })
    ]
})
```

Closes #2 