### PR TITLE
feat: add option to enable 2fa by default in `twoFactor` plugin

### DIFF
--- a/demo/nextjs/lib/auth.ts
+++ b/demo/nextjs/lib/auth.ts
@@ -181,6 +181,8 @@ const authOptions = {
 					});
 				},
 			},
+			// Uncomment to require all users to set up 2FA
+			// enableByDefault: true,
 		}),
 		passkey(),
 		openAPI(),

--- a/docs/content/docs/plugins/2fa.mdx
+++ b/docs/content/docs/plugins/2fa.mdx
@@ -251,11 +251,11 @@ After the user has entered their 2FA code, you can verify it using `twoFactor.ve
 ```ts
 type verifyTOTP = {
     /**
-     * The otp code to verify. 
+     * The otp code to verify.
      */
     code: string = "012345"
     /**
-     * If true, the device will be trusted for 30 days. It'll be refreshed on every sign in request within this time. 
+     * If true, the device will be trusted for 30 days. It'll be refreshed on every sign in request within this time.
      */
     trustDevice?: boolean = true
 }
@@ -293,7 +293,7 @@ Sending an OTP is done by calling the `twoFactor.sendOtp` function. This functio
 ```ts
 type send2FaOTP = {
     /**
-     * If true, the device will be trusted for 30 days. It'll be refreshed on every sign in request within this time. 
+     * If true, the device will be trusted for 30 days. It'll be refreshed on every sign in request within this time.
      */
     trustDevice?: boolean = true
 }
@@ -312,11 +312,11 @@ After the user has entered their OTP code, you can verify it
 ```ts
 type verifyOTP = {
     /**
-     * The otp code to verify. 
+     * The otp code to verify.
      */
     code: string = "012345"
     /**
-     * If true, the device will be trusted for 30 days. It'll be refreshed on every sign in request within this time. 
+     * If true, the device will be trusted for 30 days. It'll be refreshed on every sign in request within this time.
      */
     trustDevice?: boolean = true
 }
@@ -338,7 +338,7 @@ Generate backup codes for account recovery:
 ```ts
 type generateBackupCodes = {
     /**
-     * The users password. 
+     * The users password.
      */
     password: string
 }
@@ -363,15 +363,15 @@ You can now allow users to provide a backup code as an account recovery method.
 ```ts
 type verifyBackupCode = {
     /**
-     * A backup code to verify. 
+     * A backup code to verify.
      */
     code: string = "123456"
     /**
-     * If true, the session cookie will not be set. 
+     * If true, the session cookie will not be set.
      */
     disableSession?: boolean = false
     /**
-     * If true, the device will be trusted for 30 days. It'll be refreshed on every sign in request within this time. 
+     * If true, the device will be trusted for 30 days. It'll be refreshed on every sign in request within this time.
      */
     trustDevice?: boolean = true
 }
@@ -395,7 +395,7 @@ To display the backup codes to the user, you can call `viewBackupCodes` on the s
 ```ts
 type viewBackupCodes = {
     /**
-     * The user ID to view all backup codes. 
+     * The user ID to view all backup codes.
      */
     userId?: string | null = "user-id"
 }
@@ -464,6 +464,24 @@ Table: `twoFactor`
 
 **skipVerificationOnEnable**: Skip the verification process before enabling two factor for a user.
 
+**enableByDefault**: Require all users to set up two-factor authentication. When enabled, users without 2FA will receive a `twoFactorSetupRequired: true` response after signing in, indicating they need to enable 2FA before continuing. You can handle this similar to `twoFactorRedirect`:
+
+```ts title="sign-in.tsx"
+await authClient.signIn.email({
+        email: "user@example.com",
+        password: "password123",
+    },
+    {
+        async onSuccess(context) {
+            if (context.data.twoFactorSetupRequired) {
+                // Redirect user to enable 2FA
+                window.location.href = "/enable-2fa"
+            }
+        },
+    }
+)
+```
+
 **Issuer**: The issuer is the name of your application. It's used to generate TOTP codes. It'll be displayed in the authenticator apps.
 
 **TOTP options**
@@ -496,7 +514,7 @@ these are options for OTP.
         type: "function",
     },
     period: {
-        description: "The period for otp in minutes.", 
+        description: "The period for otp in minutes.",
         type: "number",
         default: 3,
     },
@@ -546,11 +564,11 @@ import { twoFactorClient } from "better-auth/client/plugins"
 
 const authClient =  createAuthClient({
     plugins: [
-        twoFactorClient({ // [!code highlight]
-            onTwoFactorRedirect(){ // [!code highlight]
-                window.location.href = "/2fa" // Handle the 2FA verification redirect // [!code highlight]
-            } // [!code highlight]
-        }) // [!code highlight]
+        twoFactorClient({
+            onTwoFactorRedirect(){
+                window.location.href = "/2fa" // Handle the 2FA verification redirect
+            }
+        })
     ]
 })
 ```
@@ -559,3 +577,5 @@ const authClient =  createAuthClient({
 **Options**
 
 `onTwoFactorRedirect`: A callback that will be called when the user needs to verify their 2FA code. This can be used to redirect the user to the 2FA page.
+
+`onTwoFactorSetupRequired`: A callback that will be called when the user needs to set up 2FA (when `enableByDefault` is enabled on the server). This can be used to redirect the user to the 2FA setup page.

--- a/packages/better-auth/src/context/create-context.ts
+++ b/packages/better-auth/src/context/create-context.ts
@@ -83,7 +83,9 @@ function validateSecret(
 export async function createAuthContext(
 	adapter: DBAdapter<BetterAuthOptions>,
 	options: BetterAuthOptions,
-	getDatabaseType: (database: BetterAuthOptions["database"]) => string,
+	getDatabaseType:
+		| ((database: BetterAuthOptions["database"]) => string)
+		| ((database: BetterAuthOptions["database"]) => Promise<string>),
 ): Promise<AuthContext> {
 	//set default options for stateless mode
 	if (!options.database) {
@@ -189,7 +191,7 @@ Most of the features of Better Auth will not work correctly.`,
 		database:
 			typeof options.database === "function"
 				? "adapter"
-				: getDatabaseType(options.database),
+				: await getDatabaseType(options.database),
 	});
 
 	const pluginIds = new Set(options.plugins!.map((p) => p.id));

--- a/packages/better-auth/src/context/init.ts
+++ b/packages/better-auth/src/context/init.ts
@@ -1,5 +1,4 @@
 import { BetterAuthError } from "@better-auth/core/error";
-import { getKyselyDatabaseType } from "@better-auth/kysely-adapter";
 import { getAdapter } from "../db/adapter-kysely";
 import { getMigrations } from "../db/get-migration";
 import type { BetterAuthOptions } from "../types";
@@ -9,8 +8,12 @@ export const init = async (options: BetterAuthOptions) => {
 	const adapter = await getAdapter(options);
 
 	// Get database type using Kysely's dialect detection
-	const getDatabaseType = (database: BetterAuthOptions["database"]) =>
-		getKyselyDatabaseType(database) || "unknown";
+	const getDatabaseType = async (database: BetterAuthOptions["database"]) => {
+		const { getKyselyDatabaseType } = await import(
+			"@better-auth/kysely-adapter"
+		);
+		return getKyselyDatabaseType(database) || "unknown";
+	};
 
 	// Use base context creation
 	const ctx = await createAuthContext(adapter, options, getDatabaseType);

--- a/packages/better-auth/src/plugins/two-factor/client.ts
+++ b/packages/better-auth/src/plugins/two-factor/client.ts
@@ -12,6 +12,11 @@ export const twoFactorClient = (
 				 * their two factor
 				 */
 				onTwoFactorRedirect?: () => void | Promise<void>;
+				/**
+				 * a redirect function to call if a user needs to set up
+				 * two factor authentication (when enableByDefault is true)
+				 */
+				onTwoFactorSetupRequired?: () => void | Promise<void>;
 		  }
 		| undefined,
 ) => {
@@ -43,6 +48,11 @@ export const twoFactorClient = (
 						if (context.data?.twoFactorRedirect) {
 							if (options?.onTwoFactorRedirect) {
 								await options.onTwoFactorRedirect();
+							}
+						}
+						if (context.data?.twoFactorSetupRequired) {
+							if (options?.onTwoFactorSetupRequired) {
+								await options.onTwoFactorSetupRequired();
 							}
 						}
 					},

--- a/packages/better-auth/src/plugins/two-factor/index.ts
+++ b/packages/better-auth/src/plugins/two-factor/index.ts
@@ -311,6 +311,13 @@ export const twoFactor = <O extends TwoFactorOptions>(options?: O) => {
 							return;
 						}
 
+						// Check if 2FA is required by default but not enabled
+						if (options?.enableByDefault && !data?.user.twoFactorEnabled) {
+							return ctx.json({
+								twoFactorSetupRequired: true,
+							});
+						}
+
 						if (!data?.user.twoFactorEnabled) {
 							return;
 						}

--- a/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
+++ b/packages/better-auth/src/plugins/two-factor/two-factor.test.ts
@@ -1138,3 +1138,30 @@ describe("OTP storage modes", async () => {
 		});
 	});
 });
+
+describe("enableByDefault option", async () => {
+	const { customFetchImpl, testUser } = await getTestInstance({
+		secret: DEFAULT_SECRET,
+		plugins: [
+			twoFactor({
+				enableByDefault: true,
+			}),
+		],
+	});
+
+	const client = createAuthClient({
+		plugins: [twoFactorClient()],
+		fetchOptions: {
+			customFetchImpl,
+			baseURL: "http://localhost:3000/api/auth",
+		},
+	});
+
+	it("should require 2FA setup when user signs in without 2FA enabled", async () => {
+		const res = await client.signIn.email({
+			email: testUser.email,
+			password: testUser.password,
+		});
+		expect((res.data as any)?.twoFactorSetupRequired).toBe(true);
+	});
+});

--- a/packages/better-auth/src/plugins/two-factor/types.ts
+++ b/packages/better-auth/src/plugins/two-factor/types.ts
@@ -39,6 +39,13 @@ export interface TwoFactorOptions {
 	 * @default 600 (10 minutes)
 	 */
 	twoFactorCookieMaxAge?: number | undefined;
+	/**
+	 * Require all users to set up two-factor authentication.
+	 * When enabled, users without 2FA will be prompted to enable it after signing in.
+	 *
+	 * @default false
+	 */
+	enableByDefault?: boolean | undefined;
 }
 
 export interface UserWithTwoFactor extends User {


### PR DESCRIPTION
Adds a new `enableByDefault` option to the `twoFactor` plugin that allows applications to require all users to set up two-factor authentication (2FA). When enabled, users without 2FA will be prompted to enable it after signing in.

## Usage

```typescript
import { betterAuth } from "better-auth";
import { twoFactor } from "better-auth/plugins";

export const auth = betterAuth({
    appName: "My App",
    plugins: [
        twoFactor({
            enableByDefault: true  // Require all users to set up 2FA
        })
    ]
})
```

Closes #4 